### PR TITLE
Create Composer Workflow to test PHP Projects

### DIFF
--- a/.github/workflows/php-composer.yaml
+++ b/.github/workflows/php-composer.yaml
@@ -1,0 +1,28 @@
+name: PHP Composer
+
+on: push
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Validate composer.json and composer.lock
+      run: composer validate --strict
+
+    - name: Cache Composer packages
+      id: composer-cache
+      uses: actions/cache@v2
+      with:
+        path: vendor
+        key: ${{ runner.os }}-php-${{ hashFiles('**/composer.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-php-
+
+    - name: Install dependencies
+      run: composer install --prefer-dist --no-progress
+
+    - name: Run test suite
+      run: composer run-script test

--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,9 @@
         "phpunit/phpunit": "~9.4",
         "friendsofphp/php-cs-fixer": "~3.4.0"
     },
+    "scripts": {
+        "test": "vendor/bin/phpstan"
+    },
     "autoload": {
         "psr-4": {
             "Codelicia\\Extension\\Suggestion\\": "lib/"

--- a/lib/CompletionNameSuggestionExtension.php
+++ b/lib/CompletionNameSuggestionExtension.php
@@ -22,7 +22,7 @@ final class CompletionNameSuggestionExtension implements Extension
         );
     }
 
-    public function configure(Resolver $schema)
+    public function configure(Resolver $schema): void
     {
     }
 }

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,4 @@
+parameters:
+    level: 1
+    paths:
+        - lib


### PR DESCRIPTION
In order to have a generic workflow using GitHub Actions, the project must use as convention the composer script test.
It can be used to call PHPUnit and/or other tools. Those tools can be installed via Composer as Dev dependencies.